### PR TITLE
Add stage name customization

### DIFF
--- a/lib/email_prefixer/configuration.rb
+++ b/lib/email_prefixer/configuration.rb
@@ -1,5 +1,5 @@
 module EmailPrefixer
   class Configuration
-    attr_accessor :application_name
+    attr_accessor :application_name, :stage_name
   end
 end

--- a/lib/email_prefixer/interceptor.rb
+++ b/lib/email_prefixer/interceptor.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/delegation'
+
 module EmailPrefixer
   class Interceptor
     def delivering_email(mail)
@@ -7,10 +9,16 @@ module EmailPrefixer
 
     private
 
+    delegate :application_name, :stage_name, to: :configuration
+
+    def configuration
+      EmailPrefixer.configuration
+    end
+
     def subject_prefix
       prefixes = []
-      prefixes << EmailPrefixer.configuration.application_name
-      prefixes << Rails.env.upcase unless Rails.env.production?
+      prefixes << application_name
+      prefixes << stage_name.upcase unless stage_name == "production"
       "[#{prefixes.join(' ')}] "
     end
   end

--- a/lib/email_prefixer/railtie.rb
+++ b/lib/email_prefixer/railtie.rb
@@ -6,6 +6,7 @@ module EmailPrefixer
       ActionMailer::Base.register_interceptor(interceptor)
       EmailPrefixer.configure do |config|
         config.application_name ||= app.class.parent_name
+        config.stage_name ||= Rails.env
       end
     end
   end

--- a/spec/lib/email_prefixer/interceptor_spec.rb
+++ b/spec/lib/email_prefixer/interceptor_spec.rb
@@ -2,12 +2,23 @@ require 'rails_helper'
 
 RSpec.describe EmailPrefixer::Interceptor do
   describe '#delivering_email' do
-    before do
-      ExampleMailer.simple_mail.deliver
-    end
     it 'adds prefix to delivered mail subject' do
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail.subject).to eq '[CustomApp TEST] Here is the Subject'
+      ExampleMailer.simple_mail.deliver
+      expect(last_email.subject).to eq '[CustomApp TEST] Here is the Subject'
+    end
+
+    it 'enables customizing the environment name' do
+      original_stage_name, EmailPrefixer.configuration.stage_name = EmailPrefixer.configuration.stage_name, 'staging'
+
+      ExampleMailer.simple_mail.deliver
+
+      expect(last_email.subject).to eq '[CustomApp STAGING] Here is the Subject'
+
+      EmailPrefixer.configuration.stage_name = original_stage_name
+    end
+
+    def last_email
+      ActionMailer::Base.deliveries.last
     end
   end
 end


### PR DESCRIPTION
In some deployments, per the [12-Factor App manifesto](http://12factor.net/config), the same
`Rails.env` is used for staging, QA, demo or any other production-like
deployment.

Enable the name of the stage that is added to the prefix to be
configured to accomodate these scenarios where the deploy environment is
`staging` but `Rails.env` is `production`.
