### PR TITLE
Add custom formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and Rails environment.  A helpful configuration for setting up email
 filters for non-production emails and ensuring consistency across
 all email deliveries.
 
-Examples:
+Examples with default format:
 ```
 [MyApp] Forgot Password
 [MyApp STAGING] Forgot Password
@@ -39,6 +39,7 @@ Some of the more common configuration options are listed here.
 See the source code and test suite for a full list of options.
 
 #### application_name - Customize Application Name
+
 The application name is automatically inferred from the Rails application class name
 and can be overridden via the `application_name` setting.
 
@@ -51,6 +52,7 @@ end
 ```
 
 #### stage_name - Customize Environment Stage Name
+
 The application environment/stage name is automatically
 inferred from the running Rails.env and it can be overridden
 via the `stage_name` setting.
@@ -62,6 +64,43 @@ EmailPrefixer.configure do |config|
   config.stage_name = 'demo'
 end
 ```
+
+#### subject_format - Customize format of mail subject
+
+The default format of the mail subject is `[AppName Environment] subject`, this can be changed by supplying either a **String** or something that responds to `call` such as a lambda or proc to the `subject_format` configuration option.
+
+* `application_name` - The inferred or customized name of the Rails app
+* `stage_name` - The name of the environment either inferred or customized
+* `subject` - The original mail subject header
+
+##### String format
+
+If `subject_format` is a **String** then this will be used as a basis for the format of the entire mail subject, the above arguments will be passed as references, format the subject using any number of the arguments. Note that this will be used for all environments/stage names.
+
+##### Callable
+
+If `subject_format` responds to `call` then this method will be invoked with the arguments listed above and the code can then alter the subject header as desired. An example of usage could be to change the entire format based on the environment/stage name.
+
+A lambda or proc can be used here and the arguments will be passed in the order above, the code must return a string to be used for the mail subject header.
+
+Example:
+```ruby
+# config/initializers/email_prefixer.rb
+EmailPrefixer.configure do |config|
+  # as a string
+  config.subject_format = "** %{application_name} %{stage_name} ** %{subject}"
+
+  # as something callable
+  config.subject_format = ->(application_name, stage_name, subject) {
+    if stage_name == 'production'
+      subject
+    else
+      "#{subject} [#{application_name} | #{stage_name.upcase}]"
+    end
+  }
+end
+```
+
 
 ## Contributing
 

--- a/lib/email_prefixer/configuration.rb
+++ b/lib/email_prefixer/configuration.rb
@@ -1,5 +1,22 @@
 module EmailPrefixer
   class Configuration
-    attr_accessor :application_name, :stage_name
+    attr_accessor :application_name, :stage_name, :subject_format
+
+    def subject_format
+      @subject_format ||= default_format
+    end
+
+    private
+
+    def default_format
+      ->(application_name, stage_name, subject) {
+        mail_prefix = [].tap do |prefixes|
+          prefixes << application_name
+          prefixes << stage_name.upcase unless stage_name == 'production'
+        end.join(' ')
+
+        "[#{mail_prefix}] #{subject}"
+      }
+    end
   end
 end

--- a/lib/email_prefixer/interceptor.rb
+++ b/lib/email_prefixer/interceptor.rb
@@ -1,24 +1,29 @@
 module EmailPrefixer
   class Interceptor
     extend Forwardable
-    def_delegators :@configuration, :application_name, :stage_name
+    def_delegators :configuration, :application_name, :stage_name, :subject_format
 
     def initialize
       @configuration = EmailPrefixer.configuration
     end
 
     def delivering_email(mail)
-      mail.subject.prepend(subject_prefix)
+      mail.subject = prepare_subject(mail)
     end
     alias_method :previewing_email, :delivering_email
 
     private
 
-    def subject_prefix
-      prefixes = []
-      prefixes << application_name
-      prefixes << stage_name.upcase unless stage_name == 'production'
-      "[#{prefixes.join(' ')}] "
+    attr_reader :configuration
+
+    def prepare_subject(mail)
+      if subject_format.respond_to? :call
+        subject_format.call(application_name, stage_name, mail.subject)
+      elsif subject_format.is_a? String
+        format(subject_format, {application_name: application_name, stage_name: stage_name, subject: mail.subject})
+      else
+        mail.subject
+      end
     end
   end
 end

--- a/spec/dummy/config/initializers/email_prefixer.rb
+++ b/spec/dummy/config/initializers/email_prefixer.rb
@@ -1,5 +1,11 @@
-# Example configuration
+# # Example configuration
 # EmailPrefixer.configure do |config|
-#   config.application_name = 'CustomApp' # override the default application name if desired
-#   config.stage_name = 'staging' # specify a custom environment name
+#   # override the default application name if desired
+#   config.application_name = 'CustomApp'
+
+#   # specify a custom environment name
+#   config.stage_name = 'staging'
+
+#   # change the format of the subject
+#   config.subject_format = "<%{application_name} - %{stage_name}> %{subject}"
 # end

--- a/spec/dummy/config/initializers/email_prefixer.rb
+++ b/spec/dummy/config/initializers/email_prefixer.rb
@@ -1,4 +1,5 @@
-# override the default application name
-EmailPrefixer.configure do |config|
-  config.application_name = 'CustomApp'
-end
+# Example configuration
+# EmailPrefixer.configure do |config|
+#   config.application_name = 'CustomApp' # override the default application name if desired
+#   config.stage_name = 'staging' # specify a custom environment name
+# end

--- a/spec/lib/email_prefixer/interceptor_spec.rb
+++ b/spec/lib/email_prefixer/interceptor_spec.rb
@@ -3,10 +3,14 @@ require 'rails_helper'
 RSpec.describe EmailPrefixer::Interceptor do
   describe '#delivering_email' do
     subject(:email) { ExampleMailer.simple_mail }
+
     context 'when application_name is configured' do
       before do
+        @original_app_name = EmailPrefixer.configuration.application_name
+        EmailPrefixer.configuration.application_name = 'CustomApp'
         email.deliver_now
       end
+
       it 'adds prefix to delivered mail subject' do
         expect(email.subject).to eq '[CustomApp TEST] Here is the Subject'
       end
@@ -18,11 +22,13 @@ RSpec.describe EmailPrefixer::Interceptor do
         EmailPrefixer.configuration.stage_name = 'staging'
         email.deliver_now
       end
+
       after do
         EmailPrefixer.configuration.stage_name = @original_stage_name
       end
+
       it 'adds custom stage name to subject' do
-        expect(email.subject).to eq '[CustomApp STAGING] Here is the Subject'
+        expect(email.subject).to eq '[Dummy STAGING] Here is the Subject'
       end
     end
 
@@ -32,11 +38,13 @@ RSpec.describe EmailPrefixer::Interceptor do
         EmailPrefixer.configuration.stage_name = 'production'
         email.deliver_now
       end
+
       after do
         EmailPrefixer.configuration.stage_name = @original_stage_name
       end
+
       it 'does not add the stage_name to the subject' do
-        expect(email.subject).to eq '[CustomApp] Here is the Subject'
+        expect(email.subject).to eq '[Dummy] Here is the Subject'
       end
     end
   end

--- a/spec/lib/email_prefixer/interceptor_spec.rb
+++ b/spec/lib/email_prefixer/interceptor_spec.rb
@@ -4,47 +4,113 @@ RSpec.describe EmailPrefixer::Interceptor do
   describe '#delivering_email' do
     subject(:email) { ExampleMailer.simple_mail }
 
-    context 'when application_name is configured' do
-      before do
-        @original_app_name = EmailPrefixer.configuration.application_name
-        EmailPrefixer.configuration.application_name = 'CustomApp'
+    context 'without configuration' do
+      it 'uses default app name to mail subject' do
         email.deliver_now
-      end
 
-      it 'adds prefix to delivered mail subject' do
-        expect(email.subject).to eq '[CustomApp TEST] Here is the Subject'
+        expect(email.subject).to eq '[Dummy TEST] Here is the Subject'
       end
     end
 
-    context 'when stage_name is configured' do
+    context 'with default format' do
+      context 'when application_name is configured' do
+        before do
+          @original_app_name = EmailPrefixer.configuration.application_name
+          EmailPrefixer.configuration.application_name = 'CustomApp'
+          email.deliver_now
+        end
+
+        after do
+          EmailPrefixer.configuration.application_name = @original_app_name
+        end
+
+        it 'adds custom app name to mail subject' do
+          expect(email.subject).to eq '[CustomApp TEST] Here is the Subject'
+        end
+      end
+
+      context 'when stage_name is configured' do
+        before do
+          @original_stage_name = EmailPrefixer.configuration.stage_name
+          EmailPrefixer.configuration.stage_name = 'staging'
+          email.deliver_now
+        end
+
+        after do
+          EmailPrefixer.configuration.stage_name = @original_stage_name
+        end
+
+        it 'adds custom stage name to subject' do
+          expect(email.subject).to eq '[Dummy STAGING] Here is the Subject'
+        end
+      end
+
+      context 'when stage_name == production' do
+        before do
+          @original_stage_name = EmailPrefixer.configuration.stage_name
+          EmailPrefixer.configuration.stage_name = 'production'
+          email.deliver_now
+        end
+
+        after do
+          EmailPrefixer.configuration.stage_name = @original_stage_name
+        end
+
+        it 'does not add the stage_name to the subject' do
+          expect(email.subject).to eq '[Dummy] Here is the Subject'
+        end
+      end
+    end
+
+    context 'with a custom format as string' do
       before do
-        @original_stage_name = EmailPrefixer.configuration.stage_name
-        EmailPrefixer.configuration.stage_name = 'staging'
+        @original_subject_format = EmailPrefixer.configuration.subject_format
+        EmailPrefixer.configuration.subject_format = "** %{application_name} %{stage_name} ** %{subject}"
         email.deliver_now
       end
 
       after do
-        EmailPrefixer.configuration.stage_name = @original_stage_name
+        EmailPrefixer.configuration.subject_format = @original_subject_format
       end
 
-      it 'adds custom stage name to subject' do
-        expect(email.subject).to eq '[Dummy STAGING] Here is the Subject'
+      it 'formats subject as specified' do
+        expect(email.subject).to eq '** Dummy test ** Here is the Subject'
       end
     end
 
-    context 'when stage_name == production' do
+    context 'with a custom format as lambda' do
       before do
-        @original_stage_name = EmailPrefixer.configuration.stage_name
-        EmailPrefixer.configuration.stage_name = 'production'
+        @original_subject_format = EmailPrefixer.configuration.subject_format
+        EmailPrefixer.configuration.subject_format = ->(application_name, stage_name, subject) {
+          "#{subject} - #{application_name} | #{stage_name.upcase}"
+        }
+
         email.deliver_now
       end
 
       after do
-        EmailPrefixer.configuration.stage_name = @original_stage_name
+        EmailPrefixer.configuration.subject_format = @original_subject_format
       end
 
-      it 'does not add the stage_name to the subject' do
-        expect(email.subject).to eq '[Dummy] Here is the Subject'
+      it 'formats subject as specified' do
+        expect(email.subject).to eq 'Here is the Subject - Dummy | TEST'
+      end
+    end
+
+    context 'with an unsupported custom format' do
+      before do
+        @original_subject_format = EmailPrefixer.configuration.subject_format
+        EmailPrefixer.configuration.subject_format = Object.new
+
+        email.deliver_now
+      end
+
+      after do
+        EmailPrefixer.configuration.subject_format = @original_subject_format
+      end
+
+      it 'uses no formatting' do
+        expect(email.subject).to eq 'Here is the Subject'
       end
     end
   end


### PR DESCRIPTION
Hi,
Great gem - wish we had it recently instead of lots of duplicate code adding prefixes in lots of ActionMailers :grimacing:

Ideally I would like to be able to add a prefix to the subject with just the stage name/environment in all environments _except_ production where it would just be the default subject.

This PR adds a `subject_format` config option which can be a String or something that responds to `call` so that the user can entirely customise the subject header as desired - hope this is OK and something you would like added?

The default behaviour is as before but now I have the ability to customise the format for my need. My format would be something like the README example.
