### PR TITLE
Fix rails 6 parent_name deprecation warning

### DIFF
--- a/lib/email_prefixer/railtie.rb
+++ b/lib/email_prefixer/railtie.rb
@@ -2,7 +2,11 @@ module EmailPrefixer
   class Railtie < ::Rails::Railtie
     initializer 'email_prefixer.configure_defaults' do |app|
       config = EmailPrefixer.configure do |config|
-        config.application_name ||= app.class.parent_name
+        config.application_name ||= if app.class.respond_to?(:module_parent_name)
+            app.class.module_parent_name
+          else
+            app.class.parent_name
+          end
         config.stage_name ||= Rails.env
         config.builder ||= EmailPrefixer::Configuration::DEFAULT_BUILDER
       end


### PR DESCRIPTION

```sh
DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated and will be removed in Rails 6.1. (called from <main> at config/environment.rb:5)
~/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/email_prefixer-1.2.0/lib/email_prefixer/railtie.rb:5:in `block (2 levels) in <class:Railtie>'
```