### PR TITLE
Load action_mailer lazily

### DIFF
--- a/lib/email_prefixer/railtie.rb
+++ b/lib/email_prefixer/railtie.rb
@@ -11,8 +11,10 @@ module EmailPrefixer
         config.builder ||= EmailPrefixer::Configuration::DEFAULT_BUILDER
       end
       interceptor = EmailPrefixer::Interceptor.new(config)
-      ActionMailer::Base.register_preview_interceptor(interceptor)
-      ActionMailer::Base.register_interceptor(interceptor)
+      ActiveSupport.on_load :action_mailer do
+        register_preview_interceptor(interceptor)
+        register_interceptor(interceptor)
+      end
     end
   end
 end

--- a/lib/email_prefixer/railtie.rb
+++ b/lib/email_prefixer/railtie.rb
@@ -2,7 +2,11 @@ module EmailPrefixer
   class Railtie < ::Rails::Railtie
     initializer 'email_prefixer.configure_defaults' do |app|
       config = EmailPrefixer.configure do |config|
-        config.application_name ||= app.class.parent_name
+        config.application_name ||= if app.class.respond_to?(:module_parent_name)
+            app.class.module_parent_name
+          else
+            app.class.parent_name
+          end
         config.stage_name ||= Rails.env
         config.builder ||= EmailPrefixer::Configuration::DEFAULT_BUILDER
       end

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
Append modification to https://github.com/wireframe/email_prefixer/pull/5 in order to fix deprecation notice
https://github.com/rails/rails/issues/36546
